### PR TITLE
FIX: OS X build errors on use of noreturn

### DIFF
--- a/src/Logger/LoggerUpload.h
+++ b/src/Logger/LoggerUpload.h
@@ -9,7 +9,7 @@
 
 #include <QtGlobal>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(WIN32) || defined(WIN64) || defined(OSX_DEBUG) || defined(OSX_RELEASE)
 #define NO_RETURN_VALUE
 #else
 #define NO_RETURN_VALUE Q_NORETURN


### PR DESCRIPTION
This addresses an issue where the following error was reported during `make`:
```sh
In file included from src/include/EngaugeAssert.h:10:
src/Logger/LoggerUpload.h:39:41: error: 'noreturn' attribute cannot be applied to types
   39 |                               int line) NO_RETURN_VALUE;
      |                                         ^
```

Full output was:
```sh
In file included from src/Background/BackgroundStateAbstractBase.cpp:9:
In file included from src/include/EngaugeAssert.h:10:
src/Logger/LoggerUpload.h:34:38: error: 'noreturn' attribute cannot be applied to types
   34 |                            int line) NO_RETURN_VALUE;
      |                                      ^
src/Logger/LoggerUpload.h:15:25: note: expanded from macro 'NO_RETURN_VALUE'
   15 | #define NO_RETURN_VALUE Q_NORETURN
      |                         ^
/usr/local/lib/QtCore.framework/Headers/qcompilerdetection.h:993:24: note: expanded from macro 'Q_NORETURN'
  993 | #  define Q_NORETURN [[noreturn]]
      |                        ^
In file included from src/Background/BackgroundStateAbstractBase.cpp:9:
In file included from src/include/EngaugeAssert.h:10:
src/Logger/LoggerUpload.h:39:41: error: 'noreturn' attribute cannot be applied to types
   39 |                               int line) NO_RETURN_VALUE;
      |                                         ^
src/Logger/LoggerUpload.h:15:25: note: expanded from macro 'NO_RETURN_VALUE'
   15 | #define NO_RETURN_VALUE Q_NORETURN
      |                         ^
/usr/local/lib/QtCore.framework/Headers/qcompilerdetection.h:993:24: note: expanded from macro 'Q_NORETURN'
  993 | #  define Q_NORETURN [[noreturn]]
      |                        ^
In file included from src/Background/BackgroundStateAbstractBase.cpp:9:
In file included from src/include/EngaugeAssert.h:10:
src/Logger/LoggerUpload.h:46:50: error: 'noreturn' attribute cannot be applied to types
   46 |                             const char* context) NO_RETURN_VALUE;
      |                                                  ^
src/Logger/LoggerUpload.h:15:25: note: expanded from macro 'NO_RETURN_VALUE'
   15 | #define NO_RETURN_VALUE Q_NORETURN
      |                         ^
/usr/local/lib/QtCore.framework/Headers/qcompilerdetection.h:993:24: note: expanded from macro 'Q_NORETURN'
  993 | #  define Q_NORETURN [[noreturn]]
      |                        ^
In file included from src/Background/BackgroundStateAbstractBase.cpp:11:
In file included from src/Graphics/GraphicsScene.h:10:
In file included from src/Cmd/CmdMediator.h:11:
In file included from src/Document/Document.h:10:
In file included from src/CoordSystem/CoordSystemContext.h:10:
In file included from src/CoordSystem/CoordSystem.h:10:
In file included from src/CoordSystem/CoordSystemInterface.h:24:
src/Callback/functor.h:1439:41: warning: ordered comparison of function pointers ('PtrToFunc' (aka 'void (*)()') and 'PtrToFunc') [-Wordered-compare-function-pointers]
 1439 |                         return lhs.func < rhs.func;
      |                                ~~~~~~~~ ^ ~~~~~~~~
1 warning and 3 errors generated.
make: *** [src/.objs/BackgroundStateAbstractBase.o] Error 1
``` 

There is a further issue that seems circumstantial so far:
```sh
src/Correlation/Correlation.h:10:10: fatal error: 'fftw3.h' file not found
```
